### PR TITLE
refactor: 상세 페이지 쿼리 방식 변경

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -53,9 +53,14 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
   });
 
   result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+    const { slug } = node.frontmatter;
+
     createPage({
-      path: node.frontmatter.slug,
+      path: slug,
       component: PostDetail,
+      context: {
+        slug,
+      },
     });
   });
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -52,15 +52,18 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     component: Main,
   });
 
-  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
-    const { slug } = node.frontmatter;
-
-    createPage({
-      path: slug,
-      component: PostDetail,
-      context: {
-        slug,
+  result.data.allMarkdownRemark.edges.forEach(
+    ({
+      node: {
+        frontmatter: { slug },
       },
-    });
-  });
+    }) =>
+      createPage({
+        path: slug,
+        component: PostDetail,
+        context: {
+          slug,
+        },
+      }),
+  );
 };

--- a/src/components/FolderItem.tsx
+++ b/src/components/FolderItem.tsx
@@ -14,8 +14,8 @@ const FolderItem = ({ folderInformation }: FolderItemProps) => {
     <Wrapper>
       <Typography variant="subtitle">{folder}</Typography>
       <DocumentList>
-        {documents.map(({ slug, subTitle, id }) => (
-          <DocumentItem key={id}>
+        {documents.map(({ slug, subTitle }) => (
+          <DocumentItem key={slug}>
             <LinkButton to={slug}>{subTitle}</LinkButton>
           </DocumentItem>
         ))}

--- a/src/components/PostDetailContent.tsx
+++ b/src/components/PostDetailContent.tsx
@@ -5,15 +5,15 @@ import Typography from './Typography';
 
 interface ContentProps {
   title: string;
-  pathname: string;
+  slug: string;
   selectedDocument: string;
 }
 
-const Common = ({ title, pathname, selectedDocument }: ContentProps) => {
+const Common = ({ title, slug, selectedDocument }: ContentProps) => {
   return (
     <>
       <Typography variant="h1">{title}</Typography>
-      <ViewCounter pathname={pathname} />
+      <ViewCounter slug={slug} />
       <MarkdownRenderer
         dangerouslySetInnerHTML={{ __html: selectedDocument }}
       />

--- a/src/components/ViewCounter.tsx
+++ b/src/components/ViewCounter.tsx
@@ -4,10 +4,10 @@ import styled from '@emotion/styled';
 import { isOnDevelopment } from '@/utils/helpers';
 
 interface ViewCounter {
-  pathname: string;
+  slug: string;
 }
 
-const ViewCounter = ({ pathname }: ViewCounter) => {
+const ViewCounter = ({ slug }: ViewCounter) => {
   const [viewCount, setViewCount] = useState(0);
 
   useEffect(() => {
@@ -19,24 +19,24 @@ const ViewCounter = ({ pathname }: ViewCounter) => {
       setViewCount(newViews.val());
     };
 
-    incrementViews(pathname);
+    incrementViews(slug);
 
-    firebase.database().ref(`/views`).child(pathname).on(`value`, onViews);
+    firebase.database().ref(`/views`).child(slug).on(`value`, onViews);
 
     return () => {
       if (firebase.database()) {
-        firebase.database().ref(`/views`).child(pathname).off(`value`, onViews);
+        firebase.database().ref(`/views`).child(slug).off(`value`, onViews);
       }
     };
-  }, [pathname]);
+  }, [slug]);
 
   return <View>{viewCount} views</View>;
 };
 
 export default ViewCounter;
 
-const incrementViews = async (pathname: ViewCounter['pathname']) => {
-  const ref = firebase.database().ref(`/views`).child(pathname);
+const incrementViews = async (slug: ViewCounter['slug']) => {
+  const ref = firebase.database().ref(`/views`).child(slug);
 
   ref.transaction(currentViews => {
     return currentViews + 1;

--- a/src/templates/PostDetail.tsx
+++ b/src/templates/PostDetail.tsx
@@ -1,7 +1,7 @@
 import { CollapsibleSidebar, FixedSidebar } from '@/components/Sidebar';
 import GlobalCss from '@/components/GlobalCss';
 import { graphql, PageProps } from 'gatsby';
-import { Edge } from '@/types/document';
+import { Edge, Node } from '@/types/document';
 import { ThemeProvider } from '@emotion/react';
 import { theme } from '@/utils/const';
 import useResponsiveWeb from '@/hooks/useResponsiveWeb';
@@ -14,26 +14,28 @@ import {
 } from '@/components/PostDetailContent';
 
 interface QueryResultType {
-  allMarkdownRemark: { edges: Edge[] };
+  allPosts: { edges: Edge[] };
+  selectedPost: Node;
+}
+
+interface PageContextType {
+  slug: string;
 }
 
 export default function PostDetail({
   data: {
-    allMarkdownRemark: { edges },
+    allPosts: { edges },
+    selectedPost,
   },
-  path,
-}: PageProps<QueryResultType>) {
+  pageContext: { slug },
+}: PageProps<QueryResultType, PageContextType>) {
   const [isSidebarShown, setIsSidebarShown] = useState(false);
-  const folderInformations = getFolders(edges);
-  const res = getSelectedDocument(edges, path);
   const { isUnder960px } = useResponsiveWeb();
+  const path = slug;
 
-  // TODO: 게시글이 존재하지 않는 경우에 대한 에러 핸들링 필요
-  if (!res) {
-    return <></>;
-  }
-
-  const { html: selectedDocument, title } = res;
+  const folderInformations = getFolders(edges);
+  const selectedDocument = selectedPost.html;
+  const { title } = selectedPost.frontmatter;
 
   return (
     <>
@@ -71,27 +73,22 @@ export default function PostDetail({
   );
 }
 
-const getSelectedDocument = (edges: Edge[], targetDocumentPath: string) => {
-  const edge = edges.find(({ node }: Edge) => {
-    if (node.frontmatter.slug === targetDocumentPath) {
-      return true;
-    }
-  });
-
-  let res = null;
-
-  if (edge) {
-    const { frontmatter, html } = edge.node;
-    res = { title: frontmatter.title, html };
-  }
-
-  return res;
-};
-
 export const getPosts = graphql`
-  query {
-    allMarkdownRemark(sort: { fields: frontmatter___date, order: DESC }) {
+  query ($slug: String!) {
+    allPosts: allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
+    ) {
       ...MarkdownRemarkFields
+    }
+    selectedPost: markdownRemark(frontmatter: { slug: { eq: $slug } }) {
+      frontmatter {
+        date
+        folder
+        slug
+        subTitle
+        title
+      }
+      html
     }
   }
 `;

--- a/src/templates/PostDetail.tsx
+++ b/src/templates/PostDetail.tsx
@@ -31,7 +31,6 @@ export default function PostDetail({
 }: PageProps<QueryResultType, PageContextType>) {
   const [isSidebarShown, setIsSidebarShown] = useState(false);
   const { isUnder960px } = useResponsiveWeb();
-  const path = slug;
 
   const folderInformations = getFolders(edges);
   const selectedDocument = selectedPost.html;
@@ -59,13 +58,13 @@ export default function PostDetail({
           <PostDetailContentWithoutSidebar
             title={title}
             selectedDocument={selectedDocument}
-            pathname={path}
+            slug={slug}
           />
         ) : (
           <PostDetailContentWithSidebar
             title={title}
             selectedDocument={selectedDocument}
-            pathname={path}
+            slug={slug}
           />
         )}
       </ThemeProvider>

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -29,12 +29,13 @@ interface Frontmatter {
   index: number;
 }
 
+export interface Node {
+  frontmatter: Frontmatter;
+  html: string;
+}
+
 export interface Edge {
-  node: {
-    frontmatter: Frontmatter;
-    html: string;
-    id: string;
-  };
+  node: Node;
 }
 
 export type MarkdownDocument = DocumentInformation & Frontmatter;

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -17,7 +17,6 @@ interface DocumentInformation {
   subTitle: string;
   slug: string;
   html: string;
-  id: string;
 }
 
 interface Frontmatter {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -9,7 +9,7 @@ interface FolderNameToFolderInformationMap {
 export const getFolders = (edges: Edge[]) => {
   const folderNameToFolderInformationMap = edges.reduce(
     (acc: FolderNameToFolderInformationMap, { node }: Edge) => {
-      const { frontmatter, html, id } = node;
+      const { frontmatter, html } = node;
       const { date, title, subTitle, folder, slug } = frontmatter;
       const documentInformation = {
         date,
@@ -18,7 +18,6 @@ export const getFolders = (edges: Edge[]) => {
         subTitle,
         slug,
         html,
-        id,
       };
 
       if (!Reflect.has(acc, folder)) {


### PR DESCRIPTION
쿼리로부터 포스트 리스트를 전달받은 다음 상세 페이지에 보여줄 데이터를 찾는 것이 아닌, 상세 페이지에 보여줄 데이터를 찾아서 결과를 전달받는다.

또한 사이드바에 보여줄 포스트 리스트와 상세 페이지에 보여줄 데이터를 동시에 쿼리한다.

### references
- https://stackoverflow.com/questions/66592617/gatsby-query-for-specific-post-using-slug
- https://www.codeconcisely.com/posts/how-to-run-multiple-queries-in-gatsby/