### PR TITLE
feat: 미디어 쿼리를 이용한 반응형 웹 구현

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import DarkModeToggle from './DarkModeToggle';
 import NavigationCollapseToggle from './NavigationCollapseToggle';
 import { Dispatch } from 'react';
 import Logo from './Logo';
+import useResponsiveWeb from '@/hooks/useResponsiveWeb';
 
 interface HeaderProps {
   isDetailPage?: boolean;
@@ -16,15 +17,27 @@ const Header = ({
   isSidebarShown,
   setIsSidebarShown,
 }: HeaderProps) => {
+  const { isUnder960px } = useResponsiveWeb();
+
+  const getLeftContent = () => {
+    if (!isUnder960px) {
+      return <></>;
+    }
+
+    if (isDetailPage) {
+      return <Logo />;
+    }
+
+    return (
+      <Typography variant="h1">
+        녕후킴의 프론트 엔드 개발 및 관심사 기록 블로그
+      </Typography>
+    );
+  };
+
   return (
     <Wrapper>
-      {isDetailPage ? (
-        <Logo />
-      ) : (
-        <Typography variant="h1">
-          녕후킴의 프론트 엔드 개발 및 관심사 기록 블로그
-        </Typography>
-      )}
+      {getLeftContent()}
       <ListWrapper>
         <List>
           <DarkModeToggle />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -45,9 +45,12 @@ export default Header;
 const Wrapper = styled('header')(() => ({
   width: '100%',
   padding: '0 12px',
-  display: 'flex',
+  display: 'none',
   alignItems: 'center',
   justifyContent: 'space-between',
+  '@media only screen and (max-width: 960px)': {
+    display: 'flex',
+  },
 }));
 
 const ListWrapper = styled('ul')(() => ({

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -3,17 +3,21 @@ import { MAIN_LEFT_MARGIN_WIDTH, MAIN_PURE_WIDTH } from '@/utils/const';
 import CustomLink from './CustomLink';
 import Typography from './Typography';
 import { MarkdownDocument } from '@/types/document';
+import useResponsiveWeb from '@/hooks/useResponsiveWeb';
 
 interface ContentProps {
   documents: MarkdownDocument[];
 }
 
 export const MainContent = ({ documents }: ContentProps) => {
+  const { isUnder960px } = useResponsiveWeb();
   return (
     <Wrapper>
-      {/* <Typography variant="h1">
-        프론트엔드 개발 및 관심사를 기록하는 블로그
-      </Typography> */}
+      {!isUnder960px && (
+        <Typography variant="h1">
+          프론트엔드 개발 및 관심사를 기록하는 블로그
+        </Typography>
+      )}
       <DocumentList>
         {documents?.map(({ html, title, date, slug }: MarkdownDocument) => (
           <DocumentItem key={slug}>

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -8,31 +8,25 @@ interface ContentProps {
   documents: MarkdownDocument[];
 }
 
-const Common = ({ documents }: ContentProps) => {
-  return (
-    <DocumentList>
-      {documents?.map(({ html, title, date, slug }: MarkdownDocument) => (
-        <DocumentItem key={slug}>
-          <Button to={slug}>
-            <Typography variant="h2">{title}</Typography>
-            <PostDate dateTime={date.toString()}>{formatDate(date)}</PostDate>
-            <Typography as={Description}>
-              {changeMarkdownToTextContent(html)}
-            </Typography>
-          </Button>
-        </DocumentItem>
-      ))}
-    </DocumentList>
-  );
-};
-
 export const MainContent = ({ documents }: ContentProps) => {
   return (
     <Wrapper>
       {/* <Typography variant="h1">
         프론트엔드 개발 및 관심사를 기록하는 블로그
       </Typography> */}
-      <Common documents={documents} />
+      <DocumentList>
+        {documents?.map(({ html, title, date, slug }: MarkdownDocument) => (
+          <DocumentItem key={slug}>
+            <Button to={slug}>
+              <Typography variant="h2">{title}</Typography>
+              <PostDate dateTime={date.toString()}>{formatDate(date)}</PostDate>
+              <Typography as={Description}>
+                {changeMarkdownToTextContent(html)}
+              </Typography>
+            </Button>
+          </DocumentItem>
+        ))}
+      </DocumentList>
     </Wrapper>
   );
 };

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -41,7 +41,7 @@ const Wrapper = styled('main')(() => ({
   },
   '@media only screen and (min-width: 961px)': {
     marginLeft: MAIN_LEFT_MARGIN_WIDTH,
-    display: 'flex',
+    display: 'block',
   },
 }));
 

--- a/src/components/MainContent.tsx
+++ b/src/components/MainContent.tsx
@@ -26,37 +26,29 @@ const Common = ({ documents }: ContentProps) => {
   );
 };
 
-export const MainWithoutSidebar = ({ documents }: ContentProps) => {
+export const MainContent = ({ documents }: ContentProps) => {
   return (
-    <MainContentWithoutSidebarWrapper>
-      <Common documents={documents} />
-    </MainContentWithoutSidebarWrapper>
-  );
-};
-
-export const MainWithSidebar = ({ documents }: ContentProps) => {
-  return (
-    <MainContentWithSidebarWrapper>
-      <Typography variant="h1">
+    <Wrapper>
+      {/* <Typography variant="h1">
         프론트엔드 개발 및 관심사를 기록하는 블로그
-      </Typography>
+      </Typography> */}
       <Common documents={documents} />
-    </MainContentWithSidebarWrapper>
+    </Wrapper>
   );
 };
 
-const BaseWrapper = styled('main')(() => ({
-  diplay: 'flex',
+const Wrapper = styled('main')(() => ({
+  display: 'none',
   width: MAIN_PURE_WIDTH,
   height: '100%',
-}));
-
-const MainContentWithoutSidebarWrapper = styled(BaseWrapper)(() => ({
-  margin: '0 auto',
-}));
-
-const MainContentWithSidebarWrapper = styled(BaseWrapper)(() => ({
-  marginLeft: MAIN_LEFT_MARGIN_WIDTH,
+  '@media only screen and (max-width: 960px)': {
+    margin: '0 auto',
+    display: 'flex',
+  },
+  '@media only screen and (min-width: 961px)': {
+    marginLeft: MAIN_LEFT_MARGIN_WIDTH,
+    display: 'flex',
+  },
 }));
 
 const DocumentItem = styled('li')(() => ({

--- a/src/components/PostDetailContent.tsx
+++ b/src/components/PostDetailContent.tsx
@@ -21,33 +21,23 @@ const Common = ({ title, slug, selectedDocument }: ContentProps) => {
   );
 };
 
-export const PostDetailContentWithoutSidebar = (props: ContentProps) => {
+export const PostDetailContent = (props: ContentProps) => {
   return (
-    <PostDetailContentWithoutSidebarWrapper>
+    <Wrapper>
       <Common {...props} />
-    </PostDetailContentWithoutSidebarWrapper>
+    </Wrapper>
   );
 };
 
-export const PostDetailContentWithSidebar = (props: ContentProps) => {
-  return (
-    <PostDetailContentWithSidebarWrapper>
-      <Common {...props} />
-    </PostDetailContentWithSidebarWrapper>
-  );
-};
-
-const BaseWrapper = styled('main')(() => ({
+const Wrapper = styled('main')(() => ({
   width: MAIN_PURE_WIDTH,
   height: '100%',
-}));
-
-const PostDetailContentWithoutSidebarWrapper = styled(BaseWrapper)(() => ({
-  margin: '0 auto',
-}));
-
-const PostDetailContentWithSidebarWrapper = styled(BaseWrapper)(() => ({
-  marginLeft: MAIN_LEFT_MARGIN_WIDTH,
+  '@media only screen and (max-width: 960px)': {
+    margin: '0 auto',
+  },
+  '@media only screen and (min-width: 961px)': {
+    marginLeft: MAIN_LEFT_MARGIN_WIDTH,
+  },
 }));
 
 const MarkdownRenderer = styled('div')(() => ({

--- a/src/components/PostDetailContent.tsx
+++ b/src/components/PostDetailContent.tsx
@@ -9,22 +9,18 @@ interface ContentProps {
   selectedDocument: string;
 }
 
-const Common = ({ title, slug, selectedDocument }: ContentProps) => {
+export const PostDetailContent = ({
+  title,
+  slug,
+  selectedDocument,
+}: ContentProps) => {
   return (
-    <>
+    <Wrapper>
       <Typography variant="h1">{title}</Typography>
       <ViewCounter slug={slug} />
       <MarkdownRenderer
         dangerouslySetInnerHTML={{ __html: selectedDocument }}
       />
-    </>
-  );
-};
-
-export const PostDetailContent = (props: ContentProps) => {
-  return (
-    <Wrapper>
-      <Common {...props} />
     </Wrapper>
   );
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,55 +10,51 @@ import { FolderInformation } from '@/types/document';
 
 interface SidebarProps {
   folderInformations: FolderInformation[];
+  isSidebarShown: boolean;
 }
 
-const Common = ({ folderInformations }: SidebarProps) => {
-  return (
-    <SubWrapper>
-      <SidebarHeader />
-      <FolderListWrapper>
-        <FolderList>
-          {folderInformations.map((folderInformation, index) => (
-            <FolderItem key={index} folderInformation={folderInformation} />
-          ))}
-        </FolderList>
-      </FolderListWrapper>
-    </SubWrapper>
-  );
-};
-
-export const CollapsibleSidebar = ({ folderInformations }: SidebarProps) => (
-  <CollapsibleSidebarWrapper>
-    <Common folderInformations={folderInformations} />
-  </CollapsibleSidebarWrapper>
+export const Sidebar = ({
+  folderInformations,
+  isSidebarShown,
+}: SidebarProps) => (
+  <>
+    {isSidebarShown && (
+      <Wrapper>
+        <SubWrapper>
+          <SidebarHeader />
+          <FolderListWrapper>
+            <FolderList>
+              {folderInformations.map((folderInformation, index) => (
+                <FolderItem key={index} folderInformation={folderInformation} />
+              ))}
+            </FolderList>
+          </FolderListWrapper>
+        </SubWrapper>
+      </Wrapper>
+    )}
+  </>
 );
 
-export const FixedSidebar = ({ folderInformations }: SidebarProps) => (
-  <FixedSidebarWrapper>
-    <Common folderInformations={folderInformations} />
-  </FixedSidebarWrapper>
-);
-
-const BaseWrapper = styled('div')(() => ({
+const Wrapper = styled('div')(() => ({
   height: '100vh',
-  display: 'flex',
+  display: 'none',
   flexDirection: 'column',
   left: 0,
   overflowY: 'auto',
   position: 'fixed',
   paddingRight: PADDING_BETWEEN_SIDEBAR_AND_SCROLL,
-}));
-
-const CollapsibleSidebarWrapper = styled(BaseWrapper)(() => ({
-  zIndex: 1,
-  top: 0,
-  padding: '0 12px',
-  backgroundColor: 'var(--dark-background)',
-}));
-
-const FixedSidebarWrapper = styled(BaseWrapper)(() => ({
-  width: SIDEBAR_WIDTH,
-  alignItems: 'flex-end',
+  '@media only screen and (max-width: 960px)': {
+    zIndex: 1,
+    top: 0,
+    padding: '0 12px',
+    backgroundColor: 'var(--dark-background)',
+    display: 'flex',
+  },
+  '@media only screen and (min-width: 961px)': {
+    width: SIDEBAR_WIDTH,
+    alignItems: 'flex-end',
+    display: 'flex',
+  },
 }));
 
 const SubWrapper = styled('div')(() => ({

--- a/src/hooks/usePrevious.tsx
+++ b/src/hooks/usePrevious.tsx
@@ -5,7 +5,7 @@ const usePrevious = <T,>(value: T) => {
 
   useEffect(() => {
     priorRef.current = value;
-  }, []);
+  }, [value]);
 
   return priorRef.current;
 };

--- a/src/hooks/usePrevious.tsx
+++ b/src/hooks/usePrevious.tsx
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+
+const usePrevious = <T,>(value: T) => {
+  const priorRef = useRef<T | undefined>(undefined);
+
+  useEffect(() => {
+    priorRef.current = value;
+  }, []);
+
+  return priorRef.current;
+};
+
+export default usePrevious;

--- a/src/hooks/useResponsiveWeb.ts
+++ b/src/hooks/useResponsiveWeb.ts
@@ -1,7 +1,50 @@
+import { useLayoutEffect, useRef } from 'react';
+import usePrevious from './usePrevious';
 import useWindowResize from './useWindowResize';
 
-const useResponsiveWeb = () => {
+type UseResponsiveWebProps = {
+  bp: number;
+  onIntersection: (isUnderBp: boolean) => void;
+}[];
+
+const useResponsiveWeb = (breakpoints?: UseResponsiveWebProps) => {
   const viewportWidth = useWindowResize()[0];
+  const priorViewportWidth = usePrevious(viewportWidth);
+  const isInitRef = useRef(false);
+
+  useLayoutEffect(() => {
+    if (!breakpoints?.length || !priorViewportWidth) {
+      return;
+    }
+
+    for (let i = 0; i < breakpoints.length; i++) {
+      const { bp, onIntersection } = breakpoints[i];
+
+      if (viewportWidth <= priorViewportWidth && bp >= viewportWidth) {
+        onIntersection(true);
+      } else if (viewportWidth > priorViewportWidth && bp < viewportWidth) {
+        onIntersection(false);
+      }
+    }
+  }, [viewportWidth, priorViewportWidth]);
+
+  useLayoutEffect(() => {
+    if (!breakpoints?.length || !viewportWidth || isInitRef.current) {
+      return;
+    }
+
+    for (let i = 0; i < breakpoints.length; i++) {
+      const { bp, onIntersection } = breakpoints[i];
+
+      if (bp >= viewportWidth) {
+        onIntersection(true);
+      } else if (bp < viewportWidth) {
+        onIntersection(false);
+      }
+    }
+
+    isInitRef.current = true;
+  }, [viewportWidth]);
 
   return {
     isUnder960px: viewportWidth <= 960,

--- a/src/templates/Main.tsx
+++ b/src/templates/Main.tsx
@@ -1,47 +1,36 @@
 import { graphql } from 'gatsby';
-import { CollapsibleSidebar, FixedSidebar } from '@/components/Sidebar';
+import { Sidebar } from '@/components/Sidebar';
 import GlobalCss from '@/components/GlobalCss';
 import { Edge, IndexPageProps } from '@/types/document';
 import { ThemeProvider } from '@emotion/react';
 import { theme } from '@/utils/const';
-import { MainWithSidebar, MainWithoutSidebar } from '@/components/MainContent';
+import { MainContent } from '@/components/MainContent';
 import { useState } from 'react';
 import Header from '@/components/Header';
 import { getFolders } from '@/utils/helpers';
-import useResponsiveWeb from '@/hooks/useResponsiveWeb';
 
 const Main = ({
   data: {
     allMarkdownRemark: { edges },
   },
 }: IndexPageProps) => {
-  const [isSidebarShown, setIsSidebarShown] = useState(false);
+  const [isSidebarShown, setIsSidebarShown] = useState(true);
   const documents = getDocuments(edges);
   const folderInformations = getFolders(edges);
-  const { isUnder960px } = useResponsiveWeb();
 
   return (
     <>
       <GlobalCss />
       <ThemeProvider theme={theme}>
-        {isUnder960px ? (
-          <>
-            <Header
-              isSidebarShown={isSidebarShown}
-              setIsSidebarShown={setIsSidebarShown}
-            />
-            {isSidebarShown && (
-              <CollapsibleSidebar folderInformations={folderInformations} />
-            )}
-          </>
-        ) : (
-          <FixedSidebar folderInformations={folderInformations} />
-        )}
-        {isUnder960px ? (
-          <MainWithoutSidebar documents={documents} />
-        ) : (
-          <MainWithSidebar documents={documents} />
-        )}
+        <Header
+          isSidebarShown={isSidebarShown}
+          setIsSidebarShown={setIsSidebarShown}
+        />
+        <Sidebar
+          isSidebarShown={isSidebarShown}
+          folderInformations={folderInformations}
+        />
+        <MainContent documents={documents} />
       </ThemeProvider>
     </>
   );

--- a/src/templates/Main.tsx
+++ b/src/templates/Main.tsx
@@ -8,13 +8,28 @@ import { MainContent } from '@/components/MainContent';
 import { useState } from 'react';
 import Header from '@/components/Header';
 import { getFolders } from '@/utils/helpers';
+import useResponsiveWeb from '@/hooks/useResponsiveWeb';
 
 const Main = ({
   data: {
     allMarkdownRemark: { edges },
   },
 }: IndexPageProps) => {
-  const [isSidebarShown, setIsSidebarShown] = useState(true);
+  const [isSidebarShown, setIsSidebarShown] = useState(false);
+
+  useResponsiveWeb([
+    {
+      bp: 960,
+      onIntersection: isUnderBp => {
+        if (isUnderBp) {
+          setIsSidebarShown(false);
+        } else {
+          setIsSidebarShown(true);
+        }
+      },
+    },
+  ]);
+
   const documents = getDocuments(edges);
   const folderInformations = getFolders(edges);
 

--- a/src/templates/PostDetail.tsx
+++ b/src/templates/PostDetail.tsx
@@ -1,17 +1,13 @@
-import { CollapsibleSidebar, FixedSidebar } from '@/components/Sidebar';
+import { Sidebar } from '@/components/Sidebar';
 import GlobalCss from '@/components/GlobalCss';
 import { graphql, PageProps } from 'gatsby';
 import { Edge, Node } from '@/types/document';
 import { ThemeProvider } from '@emotion/react';
 import { theme } from '@/utils/const';
-import useResponsiveWeb from '@/hooks/useResponsiveWeb';
 import Header from '@/components/Header';
 import { useState } from 'react';
 import { getFolders } from '@/utils/helpers';
-import {
-  PostDetailContentWithSidebar,
-  PostDetailContentWithoutSidebar,
-} from '@/components/PostDetailContent';
+import { PostDetailContent } from '@/components/PostDetailContent';
 
 interface QueryResultType {
   allPosts: { edges: Edge[] };
@@ -30,7 +26,6 @@ export default function PostDetail({
   pageContext: { slug },
 }: PageProps<QueryResultType, PageContextType>) {
   const [isSidebarShown, setIsSidebarShown] = useState(false);
-  const { isUnder960px } = useResponsiveWeb();
 
   const folderInformations = getFolders(edges);
   const selectedDocument = selectedPost.html;
@@ -40,33 +35,20 @@ export default function PostDetail({
     <>
       <GlobalCss />
       <ThemeProvider theme={theme}>
-        {isUnder960px ? (
-          <>
-            <Header
-              isDetailPage
-              isSidebarShown={isSidebarShown}
-              setIsSidebarShown={setIsSidebarShown}
-            />
-            {isSidebarShown && (
-              <CollapsibleSidebar folderInformations={folderInformations} />
-            )}
-          </>
-        ) : (
-          <FixedSidebar folderInformations={folderInformations} />
-        )}
-        {isUnder960px ? (
-          <PostDetailContentWithoutSidebar
-            title={title}
-            selectedDocument={selectedDocument}
-            slug={slug}
-          />
-        ) : (
-          <PostDetailContentWithSidebar
-            title={title}
-            selectedDocument={selectedDocument}
-            slug={slug}
-          />
-        )}
+        <Header
+          isDetailPage
+          isSidebarShown={isSidebarShown}
+          setIsSidebarShown={setIsSidebarShown}
+        />
+        <Sidebar
+          folderInformations={folderInformations}
+          isSidebarShown={isSidebarShown}
+        />
+        <PostDetailContent
+          title={title}
+          selectedDocument={selectedDocument}
+          slug={slug}
+        />
       </ThemeProvider>
     </>
   );

--- a/src/templates/PostDetail.tsx
+++ b/src/templates/PostDetail.tsx
@@ -8,6 +8,7 @@ import Header from '@/components/Header';
 import { useState } from 'react';
 import { getFolders } from '@/utils/helpers';
 import { PostDetailContent } from '@/components/PostDetailContent';
+import useResponsiveWeb from '@/hooks/useResponsiveWeb';
 
 interface QueryResultType {
   allPosts: { edges: Edge[] };
@@ -26,6 +27,19 @@ export default function PostDetail({
   pageContext: { slug },
 }: PageProps<QueryResultType, PageContextType>) {
   const [isSidebarShown, setIsSidebarShown] = useState(false);
+
+  useResponsiveWeb([
+    {
+      bp: 960,
+      onIntersection: isUnderBp => {
+        if (isUnderBp) {
+          setIsSidebarShown(false);
+        } else {
+          setIsSidebarShown(true);
+        }
+      },
+    },
+  ]);
 
   const folderInformations = getFolders(edges);
   const selectedDocument = selectedPost.html;


### PR DESCRIPTION
- #109

디자인 기획 자체가 구현하기 되게 까다롭다.

### heading 태그와 관련한 딜레마
사이트 디자인이 heading 태그를 적용하기 까다롭다.

960px 이하에서는 header 태그 내에 h1이 존재하고, 961px 이상부터는 main 태그 내에 h1 태그가 존재한다. 반응형 웹을 media query와 display: none 조합으로 지원하려고 하는 경우, 돔 트리 내에 두개의 h1 태그가 동시에 존재 가능하게되고 이것은 SEO에 불리하다.

그러므로 heading 태그만 미디어 쿼리를 적용하지 않고 스크립트로 처리했다. 이 경우 heading 태그가 늦게 뜸으로서 발생하는 layout shift 문제와 구글 서치봇이 데스크톱으로 진입하는 경우 h1 태그를 내려주지 못하는 이슈가 존재한다.

### SSR과 CSR에서 사이드바 처리
사이드바는 모바일 브라우저의 경우 초기 진입시 화면에 보여지지 않아야하고, 데스크탑 브라우저의 경우 초기 진입시 화면에 보여져야한다.
사이드바의 open, close 여부를 결정하는 isSidebarOpen 상태의 초기값을 true로 하는 순간 모바일 브라우저 초기 렌더링시 플리커를 피할 수 없다. false로하면 데스크탑에서 사이드바가 늦게 뜨는 이슈가 존재하고, (추측) SEO에 있어서 불리한 점이 있지 않을까 싶다.
우선은 false로 처리했다.