### PR TITLE
refactor: 불필요한 반응형 웹 코드 제거

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,6 @@ import DarkModeToggle from './DarkModeToggle';
 import NavigationCollapseToggle from './NavigationCollapseToggle';
 import { Dispatch } from 'react';
 import Logo from './Logo';
-import useResponsiveWeb from '@/hooks/useResponsiveWeb';
 import Oktocat from '@/assets/oktocat.svg';
 import LinkedIn from '@/assets/linkedin.svg';
 import CustomLink from './CustomLink';
@@ -20,27 +19,15 @@ const Header = ({
   isSidebarShown,
   setIsSidebarShown,
 }: HeaderProps) => {
-  const { isUnder960px } = useResponsiveWeb();
-
-  const getLeftContent = () => {
-    if (!isUnder960px) {
-      return <></>;
-    }
-
-    if (isDetailPage) {
-      return <Logo />;
-    }
-
-    return (
-      <Typography variant="h1">
-        녕후킴의 프론트 엔드 개발 및 관심사 기록 블로그
-      </Typography>
-    );
-  };
-
   return (
     <Wrapper>
-      {getLeftContent()}
+      {isDetailPage ? (
+        <Logo />
+      ) : (
+        <Typography variant="h1">
+          녕후킴의 프론트 엔드 개발 및 관심사 기록 블로그
+        </Typography>
+      )}
       <ListWrapper>
         <List>
           <DarkModeToggle />
@@ -74,6 +61,7 @@ const Wrapper = styled('header')(() => ({
   display: 'none',
   alignItems: 'center',
   justifyContent: 'space-between',
+
   '@media only screen and (max-width: 960px)': {
     display: 'flex',
   },


### PR DESCRIPTION
자바스크립트로 작성된 반응형 웹 코드랑, 미디어 쿼리로 작성된 반응형 웹 코드랑 같이 존재하니까 조금 코드 추적이 힘든감이 없지 않아 있네.

아래와 같은 !isUnder960px이라는 조건문 자체도 머릿속에 한번에 그려지지가 않음 -_-..
```javascript
if(!isUnder960px) {
  return <></>
}
```